### PR TITLE
Remove extraneous header settings from axios calls

### DIFF
--- a/frontend/src/store/actions/favActions.js
+++ b/frontend/src/store/actions/favActions.js
@@ -19,9 +19,7 @@ export const DELETE_ERROR = 'DELETE_ERROR';
 export const getFaves = () => (dispatch) => {
     dispatch({ type: FETCH_FAVES });
     axios
-        .get('/favorites', {
-            headers: { token: localStorage.getItem('userToken') }
-        })
+        .get('/favorites')
         .then((res) => {
             dispatch({ type: FAVES, payload: res.data });
         })
@@ -34,9 +32,7 @@ export const addFaveToTrip = newFave => (dispatch) => {
     dispatch({ type: CREATE_FAVE });
     return (
         axios
-            .post('/favorites', newFave, {
-                headers: { token: localStorage.getItem('userToken') },
-            })
+            .post('/favorites', newFave)
             .then((res) => {
                 dispatch({ type: FAVE_CREATED, payload: res.data });
             })
@@ -50,9 +46,7 @@ export const delFaveFromTrip = tripID => (dispatch) => {
     dispatch({ type: DELETE_FAVE });
     return (
         axios
-            .delete('/favorites/' + tripID, {
-                headers: { token: localStorage.getItem('userToken') },
-            })
+            .delete('/favorites/' + tripID)
             .then((res) => {
                 dispatch({ type: FAVE_DELETED, payload: res.data });
             })

--- a/frontend/src/store/actions/listActions.js
+++ b/frontend/src/store/actions/listActions.js
@@ -30,8 +30,7 @@ export const getList = () => dispatch => {
 	dispatch({ type: FETCH_LISTS });
 	axios({
 		method: 'GET',
-		url: '/tripId/lists/:listName',
-		headers: { token: localStorage.getItem('userToken') }
+		url: '/tripId/lists/:listName'
 	})
 		.then(res => {
 			dispatch({ type: LISTS, payload: res.data });
@@ -45,9 +44,7 @@ export const getList = () => dispatch => {
 export const addList = newList => dispatch => {
 	dispatch({ type: CREATE_LIST });
 	return axios
-		.post('/:tripId/lists', newList, {
-			headers: { token: localStorage.getItem('userToken') }
-		})
+		.post('/:tripId/lists', newList)
 		.then(res => {
 			dispatch({ type: LIST_CREATED, payload: res.data });
 		})
@@ -60,9 +57,7 @@ export const addList = newList => dispatch => {
 export const updateList = list => dispatch => {
 	dispatch({ type: EDIT_LIST });
 	return axios
-		.put('tripId/lists/:itemId', list, {
-			headers: { token: localStorage.getItem('userToken') }
-		})
+		.put('tripId/lists/:itemId', list)
 		.then(res => {
 			dispatch({ type: LIST_EDITED, payload: res.data });
 		})

--- a/frontend/src/store/actions/tripActions.js
+++ b/frontend/src/store/actions/tripActions.js
@@ -29,9 +29,7 @@ export const DELETE_ERROR = 'DELETE_ERROR';
 export const getTripsByUser = () => (dispatch) => {
     dispatch({ type: FETCH_TRIPS});
     axios
-        .get('/triplist', {
-            headers: { token: localStorage.getItem('userToken') }
-        })
+        .get('/triplist')
         .then((res) => {
             dispatch({ type: TRIPS, payload: res.data });
         })
@@ -44,9 +42,7 @@ export const getTripById = tripID => (dispatch) => {
     dispatch({ type: FETCH_SINGLE });
     return (
         axios
-            .get('/trip/' + tripID, {
-                headers: { token: localStorage.getItem('userToken') },
-            })
+            .get('/trip/' + tripID )
             .then((res) => {
                 dispatch({ type: FETCH_SINGLE, payload: res.data });
             })
@@ -60,9 +56,7 @@ export const addTrip = newTrip => (dispatch) => {
     dispatch({ type: CREATE_TRIP });
     return (
         axios
-            .post('/trip', newTrip, {
-                headers: { token: localStorage.getItem('userToken') },
-            })
+            .post('/trip', newTrip )
             .then((res) => {
                 dispatch({ type: TRIP_CREATED, payload: res.data });
             })
@@ -76,9 +70,7 @@ export const updateTrip = tripID => (dispatch) => {
     dispatch({ type: EDIT_TRIP });
     return (
         axios
-            .put('/trip' + tripID, {
-                headers: { token: localStorage.getItem('userToken') },
-            })
+            .put('/trip' + tripID)
             .then((res) => {
                 dispatch({ type: TRIP_EDITED, payload: res.data });
             })
@@ -92,9 +84,7 @@ export const removeTrip = tripID => (dispatch) => {
     dispatch({ type: DELETE_TRIP });
     return (
         axios
-            .delete('/trip/' + tripID, {
-                headers: { token: localStorage.getItem('userToken') },
-            })
+            .delete('/trip/' + tripID)
             .then((res) => {
                 dispatch({ type: TRIP_DELETED, payload: res.data });
             })


### PR DESCRIPTION
Removed some header configurations from the axios calls in the action creators.  The Authorization header  is configured to automatically set the user token as it's value, if token is present.